### PR TITLE
Fix mount adopted storage on CM13

### DIFF
--- a/rootdir/twrp.fstab
+++ b/rootdir/twrp.fstab
@@ -6,5 +6,5 @@
 /data                   ext4            /dev/block/mmcblk0p12   length=-32768
 /preload                ext4            /dev/block/mmcblk0p10
 
-/external_sd            vfat            /dev/block/mmcblk1p1	/dev/block/mmcblk1   flags=display="Micro SDcard";storage;wipeingui;removable
+/external_sd            auto            /dev/block/mmcblk1p1	/dev/block/mmcblk1   flags=display="Micro SDcard";storage;wipeingui;removable
 /usb-otg         vfat       /dev/block/sda1         /dev/block/sda       flags=display="USB-OTG";storage;wipeingui;removable


### PR DESCRIPTION
CM13 uses an ext4 or f2fs partition for the adopted storage. Having the filesystem as auto should cover them all.
